### PR TITLE
Add possibility to write directly to the logfile.

### DIFF
--- a/pkg/logchannel/logchannel.go
+++ b/pkg/logchannel/logchannel.go
@@ -42,6 +42,11 @@ func (l *logChannel) Write(data []byte) (int, error) {
 	return l.channel.Write(data)
 }
 
+func (l *logChannel) LogWrite(data []byte) (int, error) {
+	writeTTYRecHeader(l.writer, len(data))
+	return l.writer.Write(data)
+}
+
 func (l *logChannel) Close() error {
 	l.writer.Close()
 


### PR DESCRIPTION
Add possibility to write directly to the logfile.

I would like log more than just shell interaction in the logfile. For now, it could be used to log exec command, where command are passed directly in the ssh request (as these commands are passed in the ssh request, they are not seen in the ssh stream, thus cannot be logged). 